### PR TITLE
Allow nested sort field

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "typegoose-cursor-pagination",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -292,6 +292,12 @@
             "version": "2.4.0",
             "resolved": "https://npm.autox.network:443/@types%2fnormalize-package-data/-/normalize-package-data-2.4.0.tgz",
             "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
+            "dev": true
+        },
+        "@types/ramda": {
+            "version": "0.25.24",
+            "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.25.24.tgz",
+            "integrity": "sha512-c0TmWA7d4y9KLJJwL/cLPEfSReSgFQK9BtemcCATT48lMeyD7HG8IfGY8bamSuz/Byx1l+13hZV0PCvHsgMB3w==",
             "dev": true
         },
         "@types/tmp": {
@@ -2440,6 +2446,11 @@
             "requires": {
                 "performance-now": "^2.1.0"
             }
+        },
+        "ramda": {
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.0.tgz",
+            "integrity": "sha512-pVzZdDpWwWqEVVLshWUHjNwuVP7SfcmPraYuqocJp1yo2U1R7P+5QAfDhdItkuoGqIBnBYrtPp7rEPqDn9HlZA=="
         },
         "rc": {
             "version": "1.2.8",

--- a/package.json
+++ b/package.json
@@ -33,12 +33,14 @@
         "@typegoose/typegoose": "^6.4.0",
         "base64-url": "^2.2.0",
         "mongodb-extended-json": "^1.10.1",
-        "mongoose": "^5.4.14"
+        "mongoose": "^5.4.14",
+        "ramda": "^0.27.0"
     },
     "devDependencies": {
         "@types/base64-url": "^2.2.0",
         "@types/mongoose": "^5.3.19",
         "@types/node": "^13.9.5",
+        "@types/ramda": "0.25.24",
         "ava": "^3.5.1",
         "ava-spec": "^1.1.1",
         "mongodb-memory-server": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "typegoose-cursor-pagination",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "description": "A mongoose plugin to find results using on cursor-based pagination with support for typegoose",
     "main": "lib/index.js",
     "scripts": {

--- a/src/response.ts
+++ b/src/response.ts
@@ -1,5 +1,6 @@
 import { IPaginateResult, IPaginateOptions } from "./types";
 import * as bsonUrlEncoding from "./utils/bsonUrlEncoding";
+import R from "ramda";
 
 /**
  * Prepare a response to send back to the client
@@ -44,7 +45,7 @@ export function prepareResponse<T>(_docs: T[], options: IPaginateOptions, totalD
 function prepareCursor(doc: InstanceType<any>, sortField: string): string {
     // Always save _id for secondary sorting.
     if (sortField && sortField !== "_id") {
-        return bsonUrlEncoding.encode([doc[sortField], doc._id]);
+        return bsonUrlEncoding.encode([R.path([sortField], doc), doc._id]);
     } else {
         return bsonUrlEncoding.encode([doc._id]);
     }

--- a/src/response.ts
+++ b/src/response.ts
@@ -45,7 +45,7 @@ export function prepareResponse<T>(_docs: T[], options: IPaginateOptions, totalD
 function prepareCursor(doc: InstanceType<any>, sortField: string): string {
     // Always save _id for secondary sorting.
     if (sortField && sortField !== "_id") {
-        return bsonUrlEncoding.encode([R.path([sortField], doc), doc._id]);
+        return bsonUrlEncoding.encode([R.path(sortField.split("."), doc), doc._id]);
     } else {
         return bsonUrlEncoding.encode([doc._id]);
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
         "baseUrl": ".",
         "emitDecoratorMetadata": true,
         "experimentalDecorators": true,
+        "skipLibCheck": true,
         "paths": {
             "*": [
                 "node_modules/*",


### PR DESCRIPTION
I needed to use a custom sort field which was nested -> `date.from`. Since it just used `[key]` it will never work with dot notation of nested sort fields which Mongoose for example by default supports. I created a solution which should be fully backwards compatible using `ramda`. 

Let me know what you think. I didn't add extra tests since I wanted to make sure there wouldn't be any edge cases I didn't think of.

_ps: I've tested it manually as well and it works, which before crashed_